### PR TITLE
Generate the required status fields for resources

### DIFF
--- a/conditions.go
+++ b/conditions.go
@@ -108,7 +108,7 @@ func GenerateConditions(ctx Context, md []ConditionMetadata) []models.Condition 
 }
 
 func generateCondition(name string, yearOffset int, md []ConditionMetadata) models.Condition {
-	c := models.Condition{}
+	c := models.Condition{VerificationStatus: "confirmed"}
 	cmd := conditionByName(name, md)
 	c.Code = &models.CodeableConcept{Coding: []models.Coding{{Code: cmd.ICD9, System: "http://hl7.org/fhir/sid/icd-9"}}, Text: cmd.Display}
 	c.OnsetDateTime = &models.FHIRDateTime{Time: randomOnset(yearOffset), Precision: models.Date}

--- a/medications.go
+++ b/medications.go
@@ -23,6 +23,9 @@ func GenerateMedication(medicationID int, onset *models.FHIRDateTime, abatement 
 		ms.EffectivePeriod = &models.Period{Start: onset}
 		if abatement != nil {
 			ms.EffectivePeriod.End = abatement
+			ms.Status = "completed"
+		} else {
+			ms.Status = "active"
 		}
 		var medName string
 		if mmd.TradeName == "N/A" {

--- a/medications_test.go
+++ b/medications_test.go
@@ -21,4 +21,5 @@ func (m *MedicationSuite) TestGenerateMedication(c *C) {
 	c.Assert(med.MedicationCodeableConcept.Text, Equals, "Lisinopril 5mg Oral Tablet")
 	c.Assert(med.EffectivePeriod.Start.Time, Equals, t)
 	c.Assert(med.EffectivePeriod.End.Time, Equals, t.AddDate(0, 3, 0))
+	c.Assert(med.Status, Equals, "completed")
 }

--- a/observations.go
+++ b/observations.go
@@ -7,7 +7,7 @@ import (
 )
 
 func GenerateBP(ctx Context) []models.Observation {
-	sys, dia := models.Observation{}, models.Observation{}
+	sys, dia := models.Observation{Status: "final"}, models.Observation{Status: "final"}
 	sys.Code = &models.CodeableConcept{Coding: []models.Coding{{Code: "8480-6", System: "http://loinc.org"}}, Text: "Systolic Blood Pressure"}
 	dia.Code = &models.CodeableConcept{Coding: []models.Coding{{Code: "8462-4", System: "http://loinc.org"}}, Text: "Diastolic Blood Pressure"}
 	switch ctx.Hypertention {
@@ -28,7 +28,7 @@ func GenerateBP(ctx Context) []models.Observation {
 }
 
 func GenerateCholesterol(ctx Context) []models.Observation {
-	ldl, hdl, tri := models.Observation{}, models.Observation{}, models.Observation{}
+	ldl, hdl, tri := models.Observation{Status: "final"}, models.Observation{Status: "final"}, models.Observation{Status: "final"}
 	ldl.Code = &models.CodeableConcept{Coding: []models.Coding{{Code: "13457-7", System: "http://loinc.org"}}, Text: "Plasma LDL Cholesterol Measurement"}
 	hdl.Code = &models.CodeableConcept{Coding: []models.Coding{{Code: "2085-9", System: "http://loinc.org"}}, Text: "Plasma HDL Cholesterol Measurement"}
 	tri.Code = &models.CodeableConcept{Coding: []models.Coding{{Code: "3043-7", System: "http://loinc.org"}}, Text: "Plasma Triglyceride Measurement"}
@@ -64,7 +64,7 @@ func GenerateCholesterol(ctx Context) []models.Observation {
 }
 
 func GenerateWeightAndHeight(ctx Context) []models.Observation {
-	w, h := models.Observation{}, models.Observation{}
+	w, h := models.Observation{Status: "final"}, models.Observation{Status: "final"}
 	w.Code = &models.CodeableConcept{Coding: []models.Coding{{Code: "29463-7", System: "http://loinc.org"}}, Text: "Body Weight"}
 	h.Code = &models.CodeableConcept{Coding: []models.Coding{{Code: "8302-2", System: "http://loinc.org"}}, Text: "Body Height"}
 
@@ -79,7 +79,7 @@ func GenerateWeightAndHeight(ctx Context) []models.Observation {
 }
 
 func GenerateBloodSugars(ctx Context) []models.Observation {
-	gluc, ha1c := models.Observation{}, models.Observation{}
+	gluc, ha1c := models.Observation{Status: "final"}, models.Observation{Status: "final"}
 	gluc.Code = &models.CodeableConcept{Coding: []models.Coding{{Code: "1558-6", System: "http://loinc.org"}}, Text: "Fasting Glucose"}
 	ha1c.Code = &models.CodeableConcept{Coding: []models.Coding{{Code: "4548-4", System: "http://loinc.org"}}, Text: "Hemoglobin A1c"}
 


### PR DESCRIPTION
Generate the required status fields for conditions, medications, and observations -- defaulting to confirmed for conditions, final for observations, and active or completed for medications
