### PR TITLE
Generated Patient Report

### DIFF
--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"flag"
+	"html/template"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/intervention-engine/fhir/models"
+	"github.com/intervention-engine/ptgen"
+)
+
+func main() {
+	num := flag.Int("n", 100, "Number of patients to generate")
+	flag.Parse()
+	count := *num
+	resources := make([][]interface{}, count)
+	for i := 0; i < count; i++ {
+		resources[i] = ptgen.GeneratePatient()
+	}
+	generateReport(resources)
+}
+
+func generateReport(resources [][]interface{}) {
+	reports := make([]*PatientReportData, len(resources))
+	for i := range resources {
+		reports[i] = NewPatientReportData(resources[i])
+	}
+	sort.Sort(PatientReportDataByFamilyName(reports))
+
+	t, err := template.ParseFiles("report.template.html")
+	if err != nil {
+		panic(err)
+	}
+
+	data := struct {
+		PatientInfos []*PatientReportData
+	}{
+		reports,
+	}
+
+	err = t.Execute(os.Stdout, data)
+	if err != nil {
+		panic(err)
+	}
+}
+
+type PatientReportData struct {
+	Patient         models.Patient
+	Conditions      []models.Condition
+	Medications     []models.MedicationStatement
+	Encounters      []models.Encounter
+	EncObservations map[string][]models.Observation
+}
+
+func NewPatientReportData(resources []interface{}) *PatientReportData {
+	d := new(PatientReportData)
+	d.EncObservations = make(map[string][]models.Observation)
+	for _, r := range resources {
+		switch r := r.(type) {
+		case *models.Patient:
+			d.Patient = *r
+		case *models.Condition:
+			d.Conditions = append(d.Conditions, *r)
+		case *models.MedicationStatement:
+			d.Medications = append(d.Medications, *r)
+		case *models.Encounter:
+			d.Encounters = append(d.Encounters, *r)
+		case *models.Observation:
+			enc := strings.TrimPrefix(r.Encounter.Reference, "cid:")
+			d.EncObservations[enc] = append(d.EncObservations[enc], *r)
+		}
+	}
+	sort.Sort(ConditionsByOnset(d.Conditions))
+	sort.Sort(MedicationsByStart(d.Medications))
+	sort.Sort(EncountersByStart(d.Encounters))
+	return d
+}
+
+type PatientReportDataByFamilyName []*PatientReportData
+
+func (a PatientReportDataByFamilyName) Len() int      { return len(a) }
+func (a PatientReportDataByFamilyName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a PatientReportDataByFamilyName) Less(i, j int) bool {
+	return a[i].Patient.Name[0].Family[0] < a[j].Patient.Name[0].Family[0]
+}
+
+type ConditionsByOnset []models.Condition
+
+func (a ConditionsByOnset) Len() int      { return len(a) }
+func (a ConditionsByOnset) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a ConditionsByOnset) Less(i, j int) bool {
+	return a[i].OnsetDateTime.Time.Before(a[j].OnsetDateTime.Time)
+}
+
+type MedicationsByStart []models.MedicationStatement
+
+func (a MedicationsByStart) Len() int      { return len(a) }
+func (a MedicationsByStart) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a MedicationsByStart) Less(i, j int) bool {
+	return a[i].EffectivePeriod.Start.Time.Before(a[j].EffectivePeriod.Start.Time)
+}
+
+type EncountersByStart []models.Encounter
+
+func (a EncountersByStart) Len() int      { return len(a) }
+func (a EncountersByStart) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a EncountersByStart) Less(i, j int) bool {
+	return a[i].Period.Start.Time.Before(a[j].Period.Start.Time)
+}

--- a/cmd/report/report.template.html
+++ b/cmd/report/report.template.html
@@ -1,0 +1,145 @@
+
+{{define "DF"}}{{if . -}}
+    {{if eq .Precision "date" -}}
+      {{.Time.Format "2006-01-02" -}}
+    {{else -}}
+      {{.Time.Format "2006-01-02T15:04:05Z07:00" -}}
+    {{end -}}
+{{end}}{{end -}}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Generated Patients ({{len .PatientInfos}})</title>
+<style>
+    h1 {
+        text-align: center
+    }
+    h2, h3 {
+        margin-left: auto;
+        margin-right: auto;
+        width:80%
+    }
+    .report {
+        width:80%;
+        margin-left: auto;
+        margin-right: auto;
+        border:1px solid #C0C0C0;
+        border-collapse:collapse;
+        padding:5px;
+    }
+    .report th {
+        border:1px solid #C0C0C0;
+        padding:5px;
+        background:#F0F0F0;
+        text-align: left
+    }
+    .report td {
+        border:1px solid #C0C0C0;
+        padding:5px;
+        vertical-align:top
+    }
+    .report th.date {
+        width:15ch
+    }
+</style>
+</head>
+<body>
+<h1>Generated Patients ({{len .PatientInfos}})</h1>
+{{range .PatientInfos -}}
+{{$ptInfo := . -}}
+{{$name := (index .Patient.Name 0) -}}
+{{$address := (index .Patient.Address 0) -}}
+<p/>
+<hr/>
+<h2>{{index $name.Given 0}} {{(index $name.Family 0)}}</h2>
+<h3>Demographics</h3>
+<table class="report">
+    <thead>
+    <tr>
+        <th>Gender</th>
+        <th class="date">Birthdate</th>
+        <th>Address</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>{{.Patient.Gender}}</td>
+        <td>{{template "DF" .Patient.BirthDate}}</td>
+        <td>{{index $address.Line 0}}, {{$address.City}}, {{$address.State}} {{$address.PostalCode}}</td>
+    </tr>
+</table>
+{{if .Conditions -}}
+<h3>Conditions</h3>
+<table class="report">
+    <thead>
+    <tr>
+        <th>Name</th>
+        <th class="date">Start</th>
+        <th class="date">End</th>
+    </tr>
+    </thead>
+    <tbody>
+    {{range .Conditions -}}
+    <tr>
+        <td>{{.Code.Text}}</td>
+        <td>{{template "DF" .OnsetDateTime}}</td>
+        <td>{{template "DF" .AbatementDateTime}}</td>
+    </tr>
+    {{end -}}
+    </tbody>
+</table>
+{{end -}}
+{{if .Medications -}}
+<h3>Medications</h3>
+<table class="report">
+    <thead>
+    <tr>
+        <th>Name</th>
+        <th class="date">Start</th>
+        <th class="date">End</th>
+    </tr>
+    </thead>
+    <tbody>
+    {{range .Medications -}}
+    <tr>
+        <td>{{.MedicationCodeableConcept.Text}}</td>
+        <td>{{template "DF" .EffectivePeriod.Start}}</td>
+        <td>{{template "DF" .EffectivePeriod.End}}</td>
+    </tr>
+    {{end -}}
+    </tbody>
+</table>
+{{end -}}
+{{if .Encounters -}}
+<h3>Encounters</h3>
+<table class="report">
+    <thead>
+    <tr>
+        <th>Type</th>
+        <th class="date">Date</th>
+        <th>Observation</th>
+        <th>Value</th>
+    </tr>
+    </thead>
+    <tbody>
+    {{range .Encounters -}}
+    {{$enc := . -}}
+    {{$encObs := (index $ptInfo.EncObservations .Id) -}}
+    {{range $i, $_ := $encObs -}}
+    <tr>
+        {{if eq $i 0 -}}
+        <td rowspan="{{len $encObs}}">{{(index $enc.Type 0).Text}}</td>
+        <td rowspan="{{len $encObs}}">{{template "DF" $enc.Period.Start}}</td>
+        {{end -}}
+        <td>{{.Code.Text}}</td>
+        <td>{{.ValueQuantity.Value}} {{.ValueQuantity.Unit}}</td>
+    </tr>
+    {{end -}}
+    {{end -}}
+    </tbody>
+</table>
+{{end -}}
+{{end -}}
+</body>
+</html>

--- a/conditions.go
+++ b/conditions.go
@@ -116,13 +116,13 @@ func generateCondition(name string, yearOffset int, md []ConditionMetadata) mode
 	if recoveryDiceRoll <= cmd.AbatementChance {
 		switch cmd.RecoveryEstimate {
 		case "week":
-			c.AbatementDateTime = &models.FHIRDateTime{Time: c.OnsetDateTime.Time.AddDate(0, 0, 7), Precision: models.Timestamp}
+			c.AbatementDateTime = &models.FHIRDateTime{Time: c.OnsetDateTime.Time.AddDate(0, 0, 7), Precision: models.Date}
 		case "threeMonths":
-			c.AbatementDateTime = &models.FHIRDateTime{Time: c.OnsetDateTime.Time.AddDate(0, 3, 0), Precision: models.Timestamp}
+			c.AbatementDateTime = &models.FHIRDateTime{Time: c.OnsetDateTime.Time.AddDate(0, 3, 0), Precision: models.Date}
 		case "sixMonths":
-			c.AbatementDateTime = &models.FHIRDateTime{Time: c.OnsetDateTime.Time.AddDate(0, 6, 0), Precision: models.Timestamp}
+			c.AbatementDateTime = &models.FHIRDateTime{Time: c.OnsetDateTime.Time.AddDate(0, 6, 0), Precision: models.Date}
 		case "threeYears":
-			c.AbatementDateTime = &models.FHIRDateTime{Time: c.OnsetDateTime.Time.AddDate(3, 0, 0), Precision: models.Timestamp}
+			c.AbatementDateTime = &models.FHIRDateTime{Time: c.OnsetDateTime.Time.AddDate(3, 0, 0), Precision: models.Date}
 		}
 	}
 

--- a/medications_test.go
+++ b/medications_test.go
@@ -15,7 +15,7 @@ var _ = Suite(&MedicationSuite{})
 func (m *MedicationSuite) TestGenerateMedication(c *C) {
 	mmd := LoadMedications()
 	t := time.Now()
-	start := models.FHIRDateTime{Time: t, Precision: models.Timestamp}
+	start := models.FHIRDateTime{Time: t, Precision: models.Date}
 	end := models.FHIRDateTime{Time: t.AddDate(0, 3, 0), Precision: models.Date}
 	med := GenerateMedication(3, &start, &end, mmd)
 	c.Assert(med.MedicationCodeableConcept.Text, Equals, "Lisinopril 5mg Oral Tablet")


### PR DESCRIPTION
To support requests regarding what the generator supports, and the quality of its data, I've created a simple utility to generate a bunch of patients and then output an HTML report containing their data.

In support of this, I made a couple of medications to the generator logic as well:
- Tied the vital sign observations to the encounters which they're generated against
- Changed condition abatement datetimes to use date precision, since that's more realistic
